### PR TITLE
Optionally redirect critical or error reports to separate syslog facility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ You can configure the syslog handler by setting parameters in it's OTP applicati
     |                |                      |                                               |
     |----------------|----------------------|-----------------------------------------------|
     |                |                      |                                               |
+    | error_facility | undefined            | the syslog facility that should receive       |
+    |                |                      | reports of severity 'critical' and 'error'    |
+    |                |                      | see src/sasl_syslog.erl for a list of         |
+    |                |                      | possible values (type facility())             |
+    |                |                      |                                               |
+    |----------------|----------------------|-----------------------------------------------|
+    |                |                      |                                               |
     | formatter      | sasl_syslog_rfc5424  | The module used to encode messages.           |
     |                |                      |                                               |
     |----------------|----------------------|-----------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can configure the syslog handler by setting parameters in it's OTP applicati
     |                |                      |                                               |
     |----------------|----------------------|-----------------------------------------------|
     |                |                      |                                               |
-    | error_facility | undefined            | the syslog facility that should receive       |
+    | error_facility | daemon               | the syslog facility that should be used for   |
     |                |                      | reports of severity 'critical' and 'error'    |
     |                |                      | see src/sasl_syslog.erl for a list of         |
     |                |                      | possible values (type facility())             |

--- a/src/sasl_syslog.app.src
+++ b/src/sasl_syslog.app.src
@@ -5,13 +5,14 @@
   {applications, [kernel, stdlib]},
   {mod, {sasl_syslog_app, []}},
   {env, [
-    {enabled,      true},
-    {facility,     daemon},
-    {local_port,   0},
-    {remote_host,  {127,0,0,1}},
-    {remote_port,  auto},
-    {multiline,    false},
-    {rfc5424_bom,  false},
-    {formatter,    sasl_syslog_rfc5424}
+    {enabled,        true},
+    {facility,       daemon},
+    {error_facility, daemon},
+    {local_port,     0},
+    {remote_host,    {127,0,0,1}},
+    {remote_port,    auto},
+    {multiline,      false},
+    {rfc5424_bom,    false},
+    {formatter,      sasl_syslog_rfc5424}
   ]}
 ]}.

--- a/src/sasl_syslog_rfc5424.erl
+++ b/src/sasl_syslog_rfc5424.erl
@@ -6,11 +6,11 @@
 
 -spec send_report(sasl_syslog:udp_socket(), sasl_syslog:host(), sasl_syslog:udp_port_no(), #report{}) -> any().
 send_report(Socket, Address, Port, R = #report{}) ->
-    {ok, Facility} = application:get_env(sasl_syslog, facility),
+    Severity = sasl_syslog:report_severity(R),
     Msg = #msg{appname = "beam",
                timestamp = R#report.timestamp,
-               facility = Facility,
-               severity = sasl_syslog:report_severity(R),
+               facility = get_facility(Severity),
+               severity = Severity,
                hostname = R#report.host,
                procid = R#report.beam_pid,
                msgid = msgid_from_report(R),
@@ -68,6 +68,18 @@ msg_to_binary(M = #msg{vsn = 1}, MsgLimit) ->
     unicode:characters_to_binary(PacketL);
 msg_to_binary(_Msg, _MsgLimit) ->
     error(syslog_msg_vsn_unsupported).
+
+-spec get_facility(sasl_syslog:severity()) -> sasl_syslog:facility().
+get_facility(Severity) when Severity =:= critical orelse Severity =:= error ->
+    case application:get_env(sasl_syslog, error_facility) of
+	{ok, Facility} ->
+	    Facility;
+	undefined ->
+	    get_facility(info)
+    end;
+get_facility(_Severity) ->
+    {ok, Facility} = application:get_env(sasl_syslog, facility),
+    Facility.
 
 -spec calc_prival(sasl_syslog:facility(), sasl_syslog:severity()) -> pos_integer().
 calc_prival(Facility, Severity) ->

--- a/src/sasl_syslog_rfc5424.erl
+++ b/src/sasl_syslog_rfc5424.erl
@@ -71,12 +71,8 @@ msg_to_binary(_Msg, _MsgLimit) ->
 
 -spec get_facility(sasl_syslog:severity()) -> sasl_syslog:facility().
 get_facility(Severity) when Severity =:= critical orelse Severity =:= error ->
-    case application:get_env(sasl_syslog, error_facility) of
-	{ok, Facility} ->
-	    Facility;
-	undefined ->
-	    get_facility(info)
-    end;
+    {ok, Facility} = application:get_env(sasl_syslog, error_facility),
+    Facility;
 get_facility(_Severity) ->
     {ok, Facility} = application:get_env(sasl_syslog, facility),
     Facility.


### PR DESCRIPTION
By setting the `error_facility` property in the application environment reports with severity critical or error will be redirected to the specified facility. When not set, the current behavior is not affected.

Since having separate log files for informational and error messages is already a well-known feature for users of basho's (heavyweight) [lager](https://github.com/basho/lager) framework adopting it could make migration to `sasl_syslog` more easy.
